### PR TITLE
docs(sdg-engine): update docs to correct run command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Finally, update the configuration YAML `sdg_engine` will use to generate data:
 ### Generating the dataset
 Once you have your scene set up, you can generate data by running:
 ```bash
-poetry run python -m sdg_engine.core.main --config config.yaml
+poetry run python -m sdg_engine.main --config example.config.yaml
 ```
 
 This will produce a dataset with the following structure in your `target_path`:


### PR DESCRIPTION
Raised by #12, should now provide the correct command to try out the example as per the README.md.